### PR TITLE
preloading

### DIFF
--- a/src/app-index.ts
+++ b/src/app-index.ts
@@ -134,9 +134,10 @@ export class AppIndex extends LitElement {
     if (this.isAuthenticated) {
       this.handleInitTheme();
 
-      // Preload data during idle time if conditions are good
-      // This is lazy-imported to avoid impacting first load bundle size
-      this.initIdlePreload();
+      // Preload data during idle time, then precache critical components.
+      // Component precaching waits for data preload to finish to avoid
+      // competing for network/CPU during user interactions.
+      this.initIdlePreload().then(() => this.initComponentPrecache());
 
       // Lazy-load image preview dialog on first preview-image event
       this.initLazyImagePreview();
@@ -236,6 +237,20 @@ export class AppIndex extends LitElement {
       await initPreload();
     } catch (error) {
       console.warn('[App] Preload initialization failed:', error);
+    }
+  }
+
+  /**
+   * Precache critical components for offline use.
+   * Network-aware: precaches more on fast connections, less on slow ones.
+   */
+  private async initComponentPrecache() {
+    try {
+      const { initComponentPrecache } =
+        await import('./services/precache-components');
+      await initComponentPrecache();
+    } catch (error) {
+      console.warn('[App] Component precache failed:', error);
     }
   }
 

--- a/src/services/precache-components.ts
+++ b/src/services/precache-components.ts
@@ -1,0 +1,152 @@
+/**
+ * Component Precaching Service
+ *
+ * Precaches critical lazy-loaded components during idle time so they're
+ * available offline. Uses the Network Information API to tier precaching:
+ *
+ * - All connections (including slow/unknown): Post dialog + its full dep tree
+ * - Fast connections (4g): Additional happy-path pages (notifications, search, etc.)
+ *
+ * The SW's cache-first strategy for scripts means once a chunk is fetched,
+ * it's cached permanently (hashed filenames = immutable assets).
+ */
+
+// Network Information API type (Chromium-only)
+interface NetworkInformation {
+  effectiveType?: 'slow-2g' | '2g' | '3g' | '4g';
+  saveData?: boolean;
+}
+
+type PrecacheTask = () => Promise<unknown>;
+
+/**
+ * Determine the precaching tier based on network and user settings.
+ *
+ * Returns:
+ * - 'none'     : data saver is on — skip all precaching
+ * - 'critical' : slow/unknown connection — only post dialog
+ * - 'extended' : fast connection — post dialog + more pages
+ */
+async function getPrecacheTier(): Promise<'none' | 'critical' | 'extended'> {
+  // Respect the app's data saver setting
+  const { getSettings } = await import('./settings');
+  const settings = await getSettings();
+  if (settings.data_saver) {
+    return 'none';
+  }
+
+  const conn = (navigator as Navigator & { connection?: NetworkInformation })
+    .connection;
+
+  // If the browser exposes saveData and it's on, skip entirely
+  if (conn?.saveData) {
+    return 'none';
+  }
+
+  // Fast connection: 4g
+  if (conn?.effectiveType === '4g') {
+    return 'extended';
+  }
+
+  // Slow, moderate, or unknown (Safari/Firefox) — be conservative
+  return 'critical';
+}
+
+/**
+ * Critical tier: post dialog and its full dependency tree.
+ * This is the single most important offline feature — users expect to
+ * be able to compose posts at any time.
+ */
+function getCriticalTasks(): PrecacheTask[] {
+  return [() => import('../components/post-dialog.js')];
+}
+
+/**
+ * Extended tier: additional happy-path pages that authenticated
+ * users commonly visit. Only loaded on fast connections.
+ */
+function getExtendedTasks(): PrecacheTask[] {
+  return [
+    () => import('../pages/search-page.js'),
+    () => import('../components/notifications.js'),
+    () => import('../pages/app-profile.js'),
+  ];
+}
+
+/**
+ * Request idle callback with Safari fallback.
+ */
+function idleCallback(
+  callback: (deadline: IdleDeadline) => void,
+  options?: { timeout?: number }
+): number {
+  if ('requestIdleCallback' in window) {
+    return (
+      window as Window & { requestIdleCallback: typeof requestIdleCallback }
+    ).requestIdleCallback(callback, options);
+  }
+
+  const start = Date.now();
+  return setTimeout(() => {
+    callback({
+      didTimeout: false,
+      timeRemaining: () => Math.max(0, 50 - (Date.now() - start)),
+    });
+  }, 1) as unknown as number;
+}
+
+/**
+ * Process a queue of precache tasks one-per-idle-period to avoid
+ * blocking the main thread or saturating the network.
+ */
+function drainQueue(queue: PrecacheTask[]): void {
+  let index = 0;
+
+  const processNext = (_deadline: IdleDeadline): void => {
+    if (index >= queue.length) {
+      console.log('[Precache] All component precache tasks complete');
+      return;
+    }
+
+    const task = queue[index++];
+    task().catch((err) => {
+      console.warn('[Precache] Task failed (non-fatal):', err);
+    });
+
+    if (index < queue.length) {
+      idleCallback(processNext, { timeout: 10000 });
+    } else {
+      console.log('[Precache] All component precache tasks complete');
+    }
+  };
+
+  idleCallback(processNext, { timeout: 10000 });
+}
+
+/**
+ * Main entry point. Call after the app is loaded and authenticated.
+ * Waits for the page to be fully loaded + a delay, then starts
+ * precaching components during idle time.
+ */
+export async function initComponentPrecache(): Promise<void> {
+  // Delay before starting — the caller already waits for data preloading
+  // to finish, so this just adds breathing room before fetching chunks.
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+
+  const tier = await getPrecacheTier();
+  console.log(`[Precache] Network tier: ${tier}`);
+
+  if (tier === 'none') {
+    console.log('[Precache] Skipped: data saver enabled');
+    return;
+  }
+
+  const tasks: PrecacheTask[] = [...getCriticalTasks()];
+
+  if (tier === 'extended') {
+    tasks.push(...getExtendedTasks());
+  }
+
+  console.log(`[Precache] Queuing ${tasks.length} component precache tasks`);
+  drainQueue(tasks);
+}

--- a/src/services/preload.ts
+++ b/src/services/preload.ts
@@ -247,9 +247,10 @@ async function preloadFavorites(): Promise<void> {
 /**
  * Schedule preloading during idle time
  * Uses requestIdleCallback to avoid blocking the main thread
- * and processes one item per idle period to remain non-blocking
+ * and processes one item per idle period to remain non-blocking.
+ * Returns a promise that resolves when all tasks have completed.
  */
-export function schedulePreload(): void {
+export function schedulePreload(): Promise<void> {
   // Queue of preload tasks
   const preloadQueue = [
     preloadNotifications,
@@ -258,35 +259,42 @@ export function schedulePreload(): void {
   ];
 
   let queueIndex = 0;
+  const taskPromises: Promise<void>[] = [];
 
-  const processNextItem = (deadline: IdleDeadline): void => {
-    // Check if we have time remaining in this idle period
-    // and there are still items to process
-    while (queueIndex < preloadQueue.length && deadline.timeRemaining() > 0) {
-      const task = preloadQueue[queueIndex];
-      queueIndex++;
+  return new Promise<void>((resolve) => {
+    const processNextItem = (deadline: IdleDeadline): void => {
+      // Check if we have time remaining in this idle period
+      // and there are still items to process
+      while (queueIndex < preloadQueue.length && deadline.timeRemaining() > 0) {
+        const task = preloadQueue[queueIndex];
+        queueIndex++;
 
-      // Start the async task (it will complete after this idle callback)
-      task().catch((err) => {
-        console.warn('[Preload] Task failed:', err);
-      });
+        // Start the async task and track its completion
+        taskPromises.push(
+          task().catch((err) => {
+            console.warn('[Preload] Task failed:', err);
+          })
+        );
 
-      // Only do one task per idle callback to stay responsive
-      // The next task will be picked up in the next idle period
-      break;
-    }
+        // Only do one task per idle callback to stay responsive
+        // The next task will be picked up in the next idle period
+        break;
+      }
 
-    // If there are more items, schedule another idle callback
-    if (queueIndex < preloadQueue.length) {
-      requestIdleCallbackPolyfill(processNextItem, { timeout: 5000 });
-    } else {
-      console.log('[Preload] All preload tasks scheduled');
-    }
-  };
+      // If there are more items, schedule another idle callback
+      if (queueIndex < preloadQueue.length) {
+        requestIdleCallbackPolyfill(processNextItem, { timeout: 5000 });
+      } else {
+        console.log('[Preload] All preload tasks scheduled');
+        // Wait for all tasks to actually finish, then resolve
+        Promise.all(taskPromises).then(() => resolve());
+      }
+    };
 
-  // Start processing during idle time with a 5 second timeout
-  // The timeout ensures preloading eventually happens even on busy pages
-  requestIdleCallbackPolyfill(processNextItem, { timeout: 5000 });
+    // Start processing during idle time with a 5 second timeout
+    // The timeout ensures preloading eventually happens even on busy pages
+    requestIdleCallbackPolyfill(processNextItem, { timeout: 5000 });
+  });
 }
 
 /**
@@ -338,5 +346,5 @@ export async function initPreload(): Promise<void> {
   }
 
   console.log('[Preload] Starting idle-time preload...');
-  schedulePreload();
+  await schedulePreload();
 }


### PR DESCRIPTION
Closes #385 

This pull request introduces a new component precaching system to improve offline support and performance, especially for critical user flows. It also enhances the data preloading pipeline by making it promise-based, ensuring that component precaching only starts after data preloading is fully complete. The changes are grouped into two main themes: component precaching and improvements to data preloading.

**Component Precaching:**

* Added a new `initComponentPrecache` method in `src/app-index.ts` that precaches critical components after data preload finishes, prioritizing network and CPU resources for user interactions. (`[[1]](diffhunk://#diff-5469ebaab89ba2761ee07773d3246ed0c81fbb6be474fe6cd0865c8dc764e65aL137-R140)`, `[[2]](diffhunk://#diff-5469ebaab89ba2761ee07773d3246ed0c81fbb6be474fe6cd0865c8dc764e65aR243-R256)`)
* Implemented `src/services/precache-components.ts`, which uses the Network Information API and app data saver settings to determine how aggressively to precache components (critical vs. extended tiers). It loads the post dialog for all users and additional pages for users on fast connections, scheduling each precache task during idle time to avoid blocking the main thread. (`[src/services/precache-components.tsR1-R152](diffhunk://#diff-082087cfb80a95e104debec300aa4c44907a9ad8a45e2b34afb1b03656a86f42R1-R152)`)

**Data Preloading Improvements:**

* Refactored `schedulePreload` in `src/services/preload.ts` to return a promise that resolves when all preload tasks are finished, enabling better sequencing with component precaching. (`[[1]](diffhunk://#diff-49bca75b83512cf724796e300a5f0f28a3e8b074c6c6edcd42bc65973e029e7bL250-R253)`, `[[2]](diffhunk://#diff-49bca75b83512cf724796e300a5f0f28a3e8b074c6c6edcd42bc65973e029e7bR262-R277)`, `[[3]](diffhunk://#diff-49bca75b83512cf724796e300a5f0f28a3e8b074c6c6edcd42bc65973e029e7bR289-R297)`)
* Updated `initPreload` to `await` the completion of all preload tasks before proceeding, ensuring that subsequent operations (like component precaching) only start after preloading is done. (`[src/services/preload.tsL341-R349](diffhunk://#diff-49bca75b83512cf724796e300a5f0f28a3e8b074c6c6edcd42bc65973e029e7bL341-R349)`)