### PR TITLE
reduce battery usage of widget + new compose button in the widget

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -67,6 +67,9 @@ dependencies {
     // Coroutines for async widget data fetching
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0'
 
+    // WorkManager for reliable periodic widget refresh
+    implementation 'androidx.work:work-runtime-ktx:2.10.0'
+
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/app/src/main/java/place/coho/app/CohoDataFetcher.kt
+++ b/android/app/src/main/java/place/coho/app/CohoDataFetcher.kt
@@ -1,5 +1,6 @@
 package place.coho.app
 
+import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import kotlinx.coroutines.Dispatchers
@@ -7,9 +8,14 @@ import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.BufferedReader
+import java.io.File
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
+import java.security.MessageDigest
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
 
 data class TimelinePost(
     val id: String,
@@ -17,7 +23,8 @@ data class TimelinePost(
     val authorInitial: String,
     val avatarUrl: String,
     val content: String,
-    val createdAt: String
+    val createdAt: String,
+    val mediaPreviewUrl: String?
 )
 
 data class WidgetNotification(
@@ -79,10 +86,22 @@ object CohoDataFetcher {
 
     /**
      * Download a bitmap from a URL, scaled to the given size.
+     * Caches decoded bitmaps to disk for 24 hours to avoid re-downloading on every widget refresh.
      * Returns null on any error.
      */
-    suspend fun downloadAvatar(urlString: String, sizePx: Int): Bitmap? =
+    suspend fun downloadAvatar(context: Context, urlString: String, sizePx: Int): Bitmap? =
         withContext(Dispatchers.IO) {
+            if (urlString.isBlank()) return@withContext null
+
+            val cacheDir = File(context.cacheDir, "widget_avatars").also { it.mkdirs() }
+            val cacheFile = File(cacheDir, "${md5Hex(urlString)}_$sizePx.png")
+
+            // Serve from disk cache if < 24 hours old
+            if (cacheFile.exists() && System.currentTimeMillis() - cacheFile.lastModified() < 86_400_000L) {
+                BitmapFactory.decodeFile(cacheFile.absolutePath)?.let { return@withContext it }
+            }
+
+            // Download fresh copy
             var conn: HttpURLConnection? = null
             try {
                 val url = URL(urlString)
@@ -93,7 +112,17 @@ object CohoDataFetcher {
                 if (conn.responseCode != 200) return@withContext null
                 val raw = BitmapFactory.decodeStream(conn.inputStream)
                     ?: return@withContext null
-                Bitmap.createScaledBitmap(raw, sizePx, sizePx, true)
+                val scaled = Bitmap.createScaledBitmap(raw, sizePx, sizePx, true)
+                if (scaled != raw) raw.recycle()
+
+                // Persist to disk cache (best-effort)
+                try {
+                    cacheFile.outputStream().use { out ->
+                        scaled.compress(Bitmap.CompressFormat.PNG, 100, out)
+                    }
+                } catch (_: Exception) { }
+
+                scaled
             } catch (_: Exception) {
                 null
             } finally {
@@ -114,13 +143,21 @@ object CohoDataFetcher {
         val content = stripHtml(contentSource.optString("content", ""))
         if (content.isBlank()) return null
 
+        val mediaAttachments = contentSource.optJSONArray("media_attachments")
+        val mediaPreviewUrl = if (mediaAttachments != null && mediaAttachments.length() > 0) {
+            val first = mediaAttachments.getJSONObject(0)
+            if (first.optString("type") == "image") first.optString("preview_url", "").ifBlank { null }
+            else null
+        } else null
+
         return TimelinePost(
             id = obj.optString("id", ""),
             authorName = displayName,
             authorInitial = displayName.firstOrNull()?.uppercase() ?: "?",
             avatarUrl = avatarUrl,
             content = content.take(200),
-            createdAt = obj.optString("created_at", "")
+            createdAt = obj.optString("created_at", ""),
+            mediaPreviewUrl = mediaPreviewUrl
         )
     }
 
@@ -159,6 +196,40 @@ object CohoDataFetcher {
         "status" -> "posted"
         "update" -> "edited a post"
         else -> type
+    }
+
+    /** Stable, collision-resistant filename key for a URL. */
+    private fun md5Hex(input: String): String {
+        val digest = MessageDigest.getInstance("MD5").digest(input.toByteArray(Charsets.UTF_8))
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+
+    /**
+     * Format an ISO 8601 timestamp as a human-readable relative string.
+     * E.g. "now", "5m", "3h", "2d", "Apr 10".
+     */
+    fun relativeTime(isoString: String): String {
+        if (isoString.isBlank()) return ""
+        return try {
+            val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).apply {
+                timeZone = java.util.TimeZone.getTimeZone("UTC")
+            }
+            val date = sdf.parse(isoString.take(19)) ?: return ""
+            val diff = System.currentTimeMillis() - date.time
+            when {
+                diff < 60_000L -> "now"
+                diff < 3_600_000L -> "${diff / 60_000}m"
+                diff < 86_400_000L -> "${diff / 3_600_000}h"
+                diff < 7 * 86_400_000L -> "${diff / 86_400_000}d"
+                else -> {
+                    val months = arrayOf("Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec")
+                    val cal = Calendar.getInstance().apply { time = date }
+                    "${months[cal.get(Calendar.MONTH)]} ${cal.get(Calendar.DAY_OF_MONTH)}"
+                }
+            }
+        } catch (_: Exception) {
+            ""
+        }
     }
 
     /** Strip HTML tags and decode common entities to get plain text. */

--- a/android/app/src/main/java/place/coho/app/CohoDataFetcher.kt
+++ b/android/app/src/main/java/place/coho/app/CohoDataFetcher.kt
@@ -89,17 +89,20 @@ object CohoDataFetcher {
      * Caches decoded bitmaps to disk for 24 hours to avoid re-downloading on every widget refresh.
      * Returns null on any error.
      */
-    suspend fun downloadAvatar(context: Context, urlString: String, sizePx: Int): Bitmap? =
+    suspend fun downloadBitmap(context: Context, urlString: String, sizePx: Int): Bitmap? =
         withContext(Dispatchers.IO) {
             if (urlString.isBlank()) return@withContext null
 
-            val cacheDir = File(context.cacheDir, "widget_avatars").also { it.mkdirs() }
+            val cacheDir = File(context.cacheDir, "widget_images").also { it.mkdirs() }
             val cacheFile = File(cacheDir, "${md5Hex(urlString)}_$sizePx.png")
 
             // Serve from disk cache if < 24 hours old
             if (cacheFile.exists() && System.currentTimeMillis() - cacheFile.lastModified() < 86_400_000L) {
                 BitmapFactory.decodeFile(cacheFile.absolutePath)?.let { return@withContext it }
             }
+
+            // Expired cache file — delete before downloading a fresh copy
+            if (cacheFile.exists()) cacheFile.delete()
 
             // Download fresh copy
             var conn: HttpURLConnection? = null
@@ -110,7 +113,7 @@ object CohoDataFetcher {
                 conn.readTimeout = 5_000
                 conn.instanceFollowRedirects = true
                 if (conn.responseCode != 200) return@withContext null
-                val raw = BitmapFactory.decodeStream(conn.inputStream)
+                val raw = conn.inputStream.use { input -> BitmapFactory.decodeStream(input) }
                     ?: return@withContext null
                 val scaled = Bitmap.createScaledBitmap(raw, sizePx, sizePx, true)
                 if (scaled != raw) raw.recycle()
@@ -198,7 +201,7 @@ object CohoDataFetcher {
         else -> type
     }
 
-    /** Stable, collision-resistant filename key for a URL. */
+    /** Stable filename key for a URL (not cryptographically collision-resistant; used for cache file naming only). */
     private fun md5Hex(input: String): String {
         val digest = MessageDigest.getInstance("MD5").digest(input.toByteArray(Charsets.UTF_8))
         return digest.joinToString("") { "%02x".format(it) }
@@ -216,6 +219,7 @@ object CohoDataFetcher {
             }
             val date = sdf.parse(isoString.take(19)) ?: return ""
             val diff = System.currentTimeMillis() - date.time
+            if (diff <= 0L) return "now"
             when {
                 diff < 60_000L -> "now"
                 diff < 3_600_000L -> "${diff / 60_000}m"

--- a/android/app/src/main/java/place/coho/app/CohoWidget.kt
+++ b/android/app/src/main/java/place/coho/app/CohoWidget.kt
@@ -57,7 +57,17 @@ class CohoWidget : GlanceAppWidget() {
         val allUrls = timelinePosts.map { it.avatarUrl } + notifications.map { it.avatarUrl }
         for (url in allUrls.distinct()) {
             if (url.isNotBlank()) {
-                CohoDataFetcher.downloadAvatar(url, avatarSize)?.let { avatarCache[url] = it }
+                CohoDataFetcher.downloadAvatar(context, url, avatarSize)?.let { avatarCache[url] = it }
+            }
+        }
+
+        // Download media thumbnails for timeline posts with image attachments
+        val thumbSize = (80 * context.resources.displayMetrics.density).toInt()
+        val mediaCache = mutableMapOf<String, Bitmap>()
+        for (post in timelinePosts) {
+            val url = post.mediaPreviewUrl
+            if (!url.isNullOrBlank()) {
+                CohoDataFetcher.downloadAvatar(context, url, thumbSize)?.let { mediaCache[url] = it }
             }
         }
 
@@ -67,7 +77,8 @@ class CohoWidget : GlanceAppWidget() {
                     isAuthenticated = isAuthenticated,
                     timelinePosts = timelinePosts,
                     notifications = notifications,
-                    avatarCache = avatarCache
+                    avatarCache = avatarCache,
+                    mediaCache = mediaCache
                 )
             }
         }
@@ -78,7 +89,8 @@ class CohoWidget : GlanceAppWidget() {
         isAuthenticated: Boolean,
         timelinePosts: List<TimelinePost>,
         notifications: List<WidgetNotification>,
-        avatarCache: Map<String, Bitmap>
+        avatarCache: Map<String, Bitmap>,
+        mediaCache: Map<String, Bitmap>
     ) {
         val prefs = currentState<Preferences>()
         val selectedTab = prefs[CohoWidgetKeys.SELECTED_TAB] ?: CohoWidgetKeys.TAB_TIMELINE
@@ -91,15 +103,40 @@ class CohoWidget : GlanceAppWidget() {
                 .padding(12.dp)
         ) {
             // Header
-            Text(
-                text = "Coho",
-                style = TextStyle(
-                    color = GlanceTheme.colors.primary,
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.Bold
-                ),
-                modifier = GlanceModifier.padding(bottom = 8.dp, start = 4.dp)
-            )
+            Row(
+                modifier = GlanceModifier.fillMaxWidth().padding(bottom = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Coho",
+                    style = TextStyle(
+                        color = GlanceTheme.colors.primary,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Bold
+                    ),
+                    modifier = GlanceModifier.defaultWeight().padding(start = 4.dp)
+                )
+                Box(
+                    modifier = GlanceModifier
+                        .size(32.dp)
+                        .background(GlanceTheme.colors.primary)
+                        .cornerRadius(16.dp)
+                        .clickable(actionRunCallback<DeepLinkAction>(
+                            actionParametersOf(DeepLinkUrlKey to "https://localhost/home?newPost=1")
+                        )),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "+",
+                        style = TextStyle(
+                            color = GlanceTheme.colors.onPrimary,
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.Bold,
+                            textAlign = TextAlign.Center
+                        )
+                    )
+                }
+            }
 
             // Tab bar
             TabBar(selectedTab = selectedTab)
@@ -114,7 +151,7 @@ class CohoWidget : GlanceAppWidget() {
                     } else if (timelinePosts.isEmpty()) {
                         EmptyState("No posts yet")
                     } else {
-                        TimelineList(timelinePosts, avatarCache)
+                        TimelineList(timelinePosts, avatarCache, mediaCache)
                     }
                 }
                 CohoWidgetKeys.TAB_NOTIFICATIONS -> {
@@ -139,7 +176,7 @@ class CohoWidget : GlanceAppWidget() {
                 .padding(2.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            TabButton("Timeline", CohoWidgetKeys.TAB_TIMELINE, selectedTab,
+            TabButton("Home", CohoWidgetKeys.TAB_TIMELINE, selectedTab,
                 GlanceModifier.defaultWeight())
             Spacer(modifier = GlanceModifier.width(4.dp))
             TabButton("Notifications", CohoWidgetKeys.TAB_NOTIFICATIONS, selectedTab,
@@ -239,16 +276,16 @@ class CohoWidget : GlanceAppWidget() {
     }
 
     @Composable
-    private fun TimelineList(posts: List<TimelinePost>, avatarCache: Map<String, Bitmap>) {
+    private fun TimelineList(posts: List<TimelinePost>, avatarCache: Map<String, Bitmap>, mediaCache: Map<String, Bitmap>) {
         LazyColumn(modifier = GlanceModifier.fillMaxSize()) {
             items(posts, itemId = { it.id.hashCode().toLong() }) { post ->
-                TimelineItem(post, avatarCache[post.avatarUrl])
+                TimelineItem(post, avatarCache[post.avatarUrl], post.mediaPreviewUrl?.let { mediaCache[it] })
             }
         }
     }
 
     @Composable
-    private fun TimelineItem(post: TimelinePost, avatar: Bitmap?) {
+    private fun TimelineItem(post: TimelinePost, avatar: Bitmap?, thumbnail: Bitmap?) {
         Row(
             modifier = GlanceModifier
                 .fillMaxWidth()
@@ -290,15 +327,26 @@ class CohoWidget : GlanceAppWidget() {
             Spacer(modifier = GlanceModifier.width(8.dp))
 
             Column(modifier = GlanceModifier.defaultWeight()) {
-                Text(
-                    text = post.authorName,
-                    style = TextStyle(
-                        color = GlanceTheme.colors.onSurface,
-                        fontSize = 13.sp,
-                        fontWeight = FontWeight.Bold
-                    ),
-                    maxLines = 1
-                )
+                Row(modifier = GlanceModifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = post.authorName,
+                        style = TextStyle(
+                            color = GlanceTheme.colors.onSurface,
+                            fontSize = 13.sp,
+                            fontWeight = FontWeight.Bold
+                        ),
+                        maxLines = 1,
+                        modifier = GlanceModifier.defaultWeight()
+                    )
+                    Spacer(modifier = GlanceModifier.width(4.dp))
+                    Text(
+                        text = CohoDataFetcher.relativeTime(post.createdAt),
+                        style = TextStyle(
+                            color = GlanceTheme.colors.onSurfaceVariant,
+                            fontSize = 11.sp
+                        )
+                    )
+                }
                 Text(
                     text = post.content,
                     style = TextStyle(
@@ -307,6 +355,18 @@ class CohoWidget : GlanceAppWidget() {
                     ),
                     maxLines = 2
                 )
+                if (thumbnail != null) {
+                    Spacer(modifier = GlanceModifier.height(4.dp))
+                    Image(
+                        provider = ImageProvider(thumbnail),
+                        contentDescription = null,
+                        modifier = GlanceModifier
+                            .fillMaxWidth()
+                            .height(80.dp)
+                            .cornerRadius(8.dp),
+                        contentScale = ContentScale.Crop
+                    )
+                }
             }
         }
     }
@@ -381,6 +441,14 @@ class CohoWidget : GlanceAppWidget() {
                             fontSize = 12.sp
                         ),
                         maxLines = 1
+                    )
+                    Spacer(modifier = GlanceModifier.width(4.dp))
+                    Text(
+                        text = CohoDataFetcher.relativeTime(notif.createdAt),
+                        style = TextStyle(
+                            color = GlanceTheme.colors.onSurfaceVariant,
+                            fontSize = 11.sp
+                        )
                     )
                 }
                 if (!notif.statusContent.isNullOrBlank()) {

--- a/android/app/src/main/java/place/coho/app/CohoWidget.kt
+++ b/android/app/src/main/java/place/coho/app/CohoWidget.kt
@@ -38,6 +38,8 @@ import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextAlign
 import androidx.glance.text.TextStyle
+import androidx.glance.semantics.contentDescription
+import androidx.glance.semantics.semantics
 
 class CohoWidget : GlanceAppWidget() {
 
@@ -57,7 +59,7 @@ class CohoWidget : GlanceAppWidget() {
         val allUrls = timelinePosts.map { it.avatarUrl } + notifications.map { it.avatarUrl }
         for (url in allUrls.distinct()) {
             if (url.isNotBlank()) {
-                CohoDataFetcher.downloadAvatar(context, url, avatarSize)?.let { avatarCache[url] = it }
+                CohoDataFetcher.downloadBitmap(context, url, avatarSize)?.let { avatarCache[url] = it }
             }
         }
 
@@ -67,7 +69,7 @@ class CohoWidget : GlanceAppWidget() {
         for (post in timelinePosts) {
             val url = post.mediaPreviewUrl
             if (!url.isNullOrBlank()) {
-                CohoDataFetcher.downloadAvatar(context, url, thumbSize)?.let { mediaCache[url] = it }
+                CohoDataFetcher.downloadBitmap(context, url, thumbSize)?.let { mediaCache[url] = it }
             }
         }
 
@@ -121,6 +123,7 @@ class CohoWidget : GlanceAppWidget() {
                         .size(32.dp)
                         .background(GlanceTheme.colors.primary)
                         .cornerRadius(16.dp)
+                        .semantics { contentDescription = "New post" }
                         .clickable(actionRunCallback<DeepLinkAction>(
                             actionParametersOf(DeepLinkUrlKey to "https://localhost/home?newPost=1")
                         )),

--- a/android/app/src/main/java/place/coho/app/CohoWidgetReceiver.kt
+++ b/android/app/src/main/java/place/coho/app/CohoWidgetReceiver.kt
@@ -1,8 +1,44 @@
 package place.coho.app
 
+import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import java.util.concurrent.TimeUnit
 
 class CohoWidgetReceiver : GlanceAppWidgetReceiver() {
     override val glanceAppWidget: GlanceAppWidget = CohoWidget()
+
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        scheduleWidgetUpdates(context)
+    }
+
+    override fun onDisabled(context: Context) {
+        super.onDisabled(context)
+        WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+    }
+
+    companion object {
+        private const val WORK_NAME = "coho_widget_refresh"
+
+        @JvmStatic
+        fun scheduleWidgetUpdates(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+            val request = PeriodicWorkRequestBuilder<WidgetUpdateWorker>(30, TimeUnit.MINUTES)
+                .setConstraints(constraints)
+                .build()
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request
+            )
+        }
+    }
 }

--- a/android/app/src/main/java/place/coho/app/WidgetBridge.java
+++ b/android/app/src/main/java/place/coho/app/WidgetBridge.java
@@ -27,6 +27,7 @@ public class WidgetBridge extends Plugin {
                 .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
         prefs.edit().putString(PREF_SERVER, server).apply();
 
+        CohoWidgetReceiver.scheduleWidgetUpdates(getContext());
         WidgetRefreshHelper.INSTANCE.refreshWidgets(getContext());
         call.resolve();
     }
@@ -42,6 +43,8 @@ public class WidgetBridge extends Plugin {
                 .putString(PREF_ACCESS_TOKEN, accessToken)
                 .apply();
 
+        // Ensure the periodic WorkManager job is scheduled (handles reinstalls)
+        CohoWidgetReceiver.scheduleWidgetUpdates(getContext());
         WidgetRefreshHelper.INSTANCE.refreshWidgets(getContext());
         call.resolve();
     }

--- a/android/app/src/main/java/place/coho/app/WidgetBridge.java
+++ b/android/app/src/main/java/place/coho/app/WidgetBridge.java
@@ -1,5 +1,7 @@
 package place.coho.app;
 
+import android.appwidget.AppWidgetManager;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.SharedPreferences;
 
@@ -27,7 +29,9 @@ public class WidgetBridge extends Plugin {
                 .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
         prefs.edit().putString(PREF_SERVER, server).apply();
 
-        CohoWidgetReceiver.scheduleWidgetUpdates(getContext());
+        if (hasActiveWidgets()) {
+            CohoWidgetReceiver.scheduleWidgetUpdates(getContext());
+        }
         WidgetRefreshHelper.INSTANCE.refreshWidgets(getContext());
         call.resolve();
     }
@@ -43,8 +47,10 @@ public class WidgetBridge extends Plugin {
                 .putString(PREF_ACCESS_TOKEN, accessToken)
                 .apply();
 
-        // Ensure the periodic WorkManager job is scheduled (handles reinstalls)
-        CohoWidgetReceiver.scheduleWidgetUpdates(getContext());
+        // Ensure the periodic WorkManager job is scheduled when widget is active (handles reinstalls)
+        if (hasActiveWidgets()) {
+            CohoWidgetReceiver.scheduleWidgetUpdates(getContext());
+        }
         WidgetRefreshHelper.INSTANCE.refreshWidgets(getContext());
         call.resolve();
     }
@@ -53,5 +59,11 @@ public class WidgetBridge extends Plugin {
     public void refresh(PluginCall call) {
         WidgetRefreshHelper.INSTANCE.refreshWidgets(getContext());
         call.resolve();
+    }
+
+    private boolean hasActiveWidgets() {
+        AppWidgetManager mgr = AppWidgetManager.getInstance(getContext());
+        ComponentName cn = new ComponentName(getContext(), CohoWidgetReceiver.class);
+        return mgr.getAppWidgetIds(cn).length > 0;
     }
 }

--- a/android/app/src/main/java/place/coho/app/WidgetUpdateWorker.kt
+++ b/android/app/src/main/java/place/coho/app/WidgetUpdateWorker.kt
@@ -1,9 +1,11 @@
 package place.coho.app
 
 import android.content.Context
+import android.util.Log
 import androidx.glance.appwidget.updateAll
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import java.io.IOException
 
 /**
  * WorkManager worker that refreshes all Coho widget instances.
@@ -16,12 +18,20 @@ class WidgetUpdateWorker(
     params: WorkerParameters
 ) : CoroutineWorker(context, params) {
 
+    companion object {
+        private const val TAG = "WidgetUpdateWorker"
+    }
+
     override suspend fun doWork(): Result {
         return try {
             CohoWidget().updateAll(applicationContext)
             Result.success()
-        } catch (_: Exception) {
+        } catch (e: IOException) {
+            Log.e(TAG, "Widget update failed (transient)", e)
             Result.retry()
+        } catch (e: Exception) {
+            Log.e(TAG, "Widget update failed (non-transient)", e)
+            Result.failure()
         }
     }
 }

--- a/android/app/src/main/java/place/coho/app/WidgetUpdateWorker.kt
+++ b/android/app/src/main/java/place/coho/app/WidgetUpdateWorker.kt
@@ -1,0 +1,27 @@
+package place.coho.app
+
+import android.content.Context
+import androidx.glance.appwidget.updateAll
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+
+/**
+ * WorkManager worker that refreshes all Coho widget instances.
+ * Scheduled as a periodic task in [CohoWidgetReceiver] so the widget
+ * reliably updates every 30 minutes whenever the device has network access,
+ * independent of the unreliable system updatePeriodMillis broadcast.
+ */
+class WidgetUpdateWorker(
+    context: Context,
+    params: WorkerParameters
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        return try {
+            CohoWidget().updateAll(applicationContext)
+            Result.success()
+        } catch (_: Exception) {
+            Result.retry()
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds support for media image previews in timeline posts, improves widget UI with relative timestamps and a new post button, and introduces a robust periodic refresh mechanism using WorkManager. It also implements disk caching for avatar and media images to reduce network usage and improve widget performance.

**Widget UI and Timeline Enhancements:**
* Timeline posts now display image previews for posts with media attachments, using a new `mediaPreviewUrl` field in `TimelinePost` and fetching/caching thumbnails for display. [[1]](diffhunk://#diff-9ced03296883eb136dbbd7a0b6d5cc086379c77a0f6f86f87d22427775a16552R3-R27) [[2]](diffhunk://#diff-9ced03296883eb136dbbd7a0b6d5cc086379c77a0f6f86f87d22427775a16552R146-R160) [[3]](diffhunk://#diff-e0579a1ca0f2836199f1bb2535788fc6f0e049adb11b2c8fd4b307f654a25d5eL60-R70) [[4]](diffhunk://#diff-e0579a1ca0f2836199f1bb2535788fc6f0e049adb11b2c8fd4b307f654a25d5eL70-R81) [[5]](diffhunk://#diff-e0579a1ca0f2836199f1bb2535788fc6f0e049adb11b2c8fd4b307f654a25d5eL81-R93) [[6]](diffhunk://#diff-e0579a1ca0f2836199f1bb2535788fc6f0e049adb11b2c8fd4b307f654a25d5eL117-R154) [[7]](diffhunk://#diff-e0579a1ca0f2836199f1bb2535788fc6f0e049adb11b2c8fd4b307f654a25d5eL242-R288) [[8]](diffhunk://#diff-e0579a1ca0f2836199f1bb2535788fc6f0e049adb11b2c8fd4b307f654a25d5eR330-R349) [[9]](diffhunk://#diff-e0579a1ca0f2836199f1bb2535788fc6f0e049adb11b2c8fd4b307f654a25d5eR358-R369)
* Relative timestamps (e.g., "now", "5m", "2d") are shown for posts and notifications, using the new `relativeTime` utility. [[1]](diffhunk://#diff-9ced03296883eb136dbbd7a0b6d5cc086379c77a0f6f86f87d22427775a16552R201-R234) [[2]](diffhunk://#diff-e0579a1ca0f2836199f1bb2535788fc6f0e049adb11b2c8fd4b307f654a25d5eR330-R349) [[3]](diffhunk://#diff-e0579a1ca0f2836199f1bb2535788fc6f0e049adb11b2c8fd4b307f654a25d5eR445-R452)
* The widget header now includes a prominent "+" button to start a new post, and the "Timeline" tab is renamed to "Home" for clarity. [[1]](diffhunk://#diff-e0579a1ca0f2836199f1bb2535788fc6f0e049adb11b2c8fd4b307f654a25d5eR106-R139) [[2]](diffhunk://#diff-e0579a1ca0f2836199f1bb2535788fc6f0e049adb11b2c8fd4b307f654a25d5eL142-R179)

**Image Caching and Performance:**
* Avatar and media image downloads are now cached to disk for 24 hours, reducing redundant network usage and speeding up widget refreshes. [[1]](diffhunk://#diff-9ced03296883eb136dbbd7a0b6d5cc086379c77a0f6f86f87d22427775a16552R89-R104) [[2]](diffhunk://#diff-9ced03296883eb136dbbd7a0b6d5cc086379c77a0f6f86f87d22427775a16552L96-R125)

**Widget Refresh Reliability:**
* Introduces a new `WidgetUpdateWorker` and schedules it with WorkManager to refresh widgets every 30 minutes when network is available, ensuring reliable updates even when the system's update broadcasts are missed. [[1]](diffhunk://#diff-9526ccfd1d1813ed49c39f8c54dbeb512607376a007d824b905bc8b4e4d202d9R70-R72) [[2]](diffhunk://#diff-446b9ee271c54362c844e483f2625e3b0f0a9f2da4b345035355bfdfe70bdba0R3-R43) [[3]](diffhunk://#diff-531a09a10fd9ba498a828cff7f183402d79c8000aeaf7358de60d50bfc2fd31eR1-R27)
* Ensures the periodic refresh job is scheduled when server or credentials are set, improving robustness after reinstalls or configuration changes. [[1]](diffhunk://#diff-c59eac9eae9ef01dc7c53354405c779a061e51cfc5a31f3754f357f72671ef52R30) [[2]](diffhunk://#diff-c59eac9eae9ef01dc7c53354405c779a061e51cfc5a31f3754f357f72671ef52R46-R47)