### PR TITLE
proofreading dialog no longer cut off

### DIFF
--- a/src/components/md/md-dropdown.ts
+++ b/src/components/md/md-dropdown.ts
@@ -8,6 +8,8 @@ import { customElement, property, query } from 'lit/decorators.js';
 @customElement('md-dropdown')
 export class MdDropdown extends LitElement {
   @property({ type: Boolean, reflect: true }) open = false;
+  /** When true, clicking a menu item will NOT auto-close the dropdown. */
+  @property({ type: Boolean }) keepOpen = false;
   @property({ type: String }) placement:
     | 'bottom-start'
     | 'bottom-end'
@@ -87,6 +89,7 @@ export class MdDropdown extends LitElement {
 
   private _handlePopupClick = (e: Event) => {
     // Close dropdown when a menu item is clicked
+    if (this.keepOpen) return;
     const target = e.target as HTMLElement;
     if (target.tagName === 'MD-MENU-ITEM' || target.closest('md-menu-item')) {
       // Small delay to allow the click handler to fire first

--- a/src/components/md/md-menu-item.ts
+++ b/src/components/md/md-menu-item.ts
@@ -234,6 +234,11 @@ export class MdMenuItem extends LitElement {
       }
 
       /* On-device indicator - shown as badge on right side */
+      /* Reserve space so label text doesn't overlap the badge */
+      :host([title]) .menu-item {
+        padding-right: 90px;
+      }
+
       :host([title])::after {
         content: attr(title);
         position: absolute;

--- a/src/components/post-composer.ts
+++ b/src/components/post-composer.ts
@@ -21,6 +21,7 @@ import './handwriting-dialog.js';
 import './quoted-post.js';
 
 import type { MdTextArea } from './md/md-text-area.js';
+import type { MdDropdown } from './md/md-dropdown.js';
 
 import {
   publishPost,
@@ -248,6 +249,7 @@ export class PostComposer extends LitElement {
   @query('media-edit-dialog')
   private mediaEditDialog!: import('./media-edit-dialog').MediaEditDialog;
   @query('#emoji-trigger') private _emojiButton!: HTMLElement;
+  @query('#more-options-dropdown') private _moreOptionsDropdown?: MdDropdown;
 
   static styles = [
     spinAnimation,
@@ -650,14 +652,12 @@ export class PostComposer extends LitElement {
 
       /* Proofread styles */
       .proofread-result-container {
-        position: relative;
+        width: 100%;
       }
 
       .proofread-dropdown {
-        position: absolute;
-        top: 100%;
-        right: 0;
-        width: 320px;
+        width: 100%;
+        box-sizing: border-box;
         margin-top: 4px;
         padding: 8px 0;
         background-color: var(--md-sys-color-surface-container, #2b2930);
@@ -1983,6 +1983,11 @@ export class PostComposer extends LitElement {
     this.proofreading = true;
     this.proofreadResult = null;
 
+    // Keep the dropdown open so the "Checking..." loading state is visible
+    if (this._moreOptionsDropdown) {
+      this._moreOptionsDropdown.keepOpen = true;
+    }
+
     try {
       const result = await proofread(text);
       this.proofreadResult = result;
@@ -1990,6 +1995,11 @@ export class PostComposer extends LitElement {
       console.error('Proofreading failed:', error);
     } finally {
       this.proofreading = false;
+      // Re-enable auto-close and hide the dropdown now that result is ready
+      if (this._moreOptionsDropdown) {
+        this._moreOptionsDropdown.keepOpen = false;
+        this._moreOptionsDropdown.hide();
+      }
     }
   }
 
@@ -2880,7 +2890,7 @@ export class PostComposer extends LitElement {
         ></md-icon-button>
 
         <!-- Overflow menu -->
-        <md-dropdown placement="bottom-end">
+        <md-dropdown id="more-options-dropdown" placement="bottom-end">
           <md-icon-button
             slot="trigger"
             name="ellipsis-vertical"
@@ -2957,10 +2967,9 @@ export class PostComposer extends LitElement {
               : nothing}
           </md-menu>
         </md-dropdown>
-
-        <!-- Proofread result (outside overflow menu) -->
-        ${this.proofreaderAvailable ? this._renderProofreadResult() : nothing}
       </div>
+      <!-- Proofread result (below actions row, full-width) -->
+      ${this.proofreaderAvailable ? this._renderProofreadResult() : nothing}
     `;
   }
 


### PR DESCRIPTION
This pull request enhances the dropdown and proofreading experience in the post composer by introducing a new `keepOpen` property to the `md-dropdown` component, improving the display and interaction of the proofread result, and making style adjustments for better usability. The most important changes are grouped below:

**Dropdown Behavior Improvements:**

* Added a `keepOpen` property to the `MdDropdown` component, allowing dropdowns to remain open when needed (e.g., during loading states). The dropdown now respects this property and will not auto-close when a menu item is clicked if `keepOpen` is true. [[1]](diffhunk://#diff-d4ea60b1f5b6f7782c642af93d0736c5c7ef0ec044284ebc715ce9a891b88c8bR11-R12) [[2]](diffhunk://#diff-d4ea60b1f5b6f7782c642af93d0736c5c7ef0ec044284ebc715ce9a891b88c8bR92)
* The post composer now references the overflow menu dropdown (`_moreOptionsDropdown`) and toggles its `keepOpen` property while proofreading is in progress, ensuring the dropdown stays open to show the "Checking..." state and then closes automatically when done. [[1]](diffhunk://#diff-d12a53deb44be603cf8637106e0468c22eb32509a1626d60e16d117172876803R252) [[2]](diffhunk://#diff-d12a53deb44be603cf8637106e0468c22eb32509a1626d60e16d117172876803R1986-R2002) [[3]](diffhunk://#diff-d12a53deb44be603cf8637106e0468c22eb32509a1626d60e16d117172876803L2883-R2893)

**Proofread Result Display and Styling:**

* Moved the proofread result display to appear below the actions row and span the full width of the composer, rather than inside the dropdown, for better visibility and alignment.
* Updated proofread result container and dropdown styles to use `width: 100%` and improved box sizing for more consistent layout.

**Menu Item Usability:**

* Improved `md-menu-item` styling to reserve space for the on-device indicator badge, preventing label text from overlapping the badge.