### PR TITLE
split up some modules + adjust modulepreload chunks

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -179,7 +179,11 @@ customPlugins.push({
     handler(html: string, { bundle }: { bundle?: Record<string, unknown> }) {
       if (!bundle) return html;
 
-      const chunksToPreload = ['vendor-idb-keyval'];
+      const chunksToPreload = [
+        'auth-session',
+        'vendor-idb-keyval',
+        'firebase-',
+      ];
       const preloadLinks: string[] = [];
 
       for (const chunkPattern of chunksToPreload) {
@@ -301,6 +305,14 @@ export default defineConfig({
       ],
       output: {
         manualChunks(id) {
+          if (id.includes('src/utils/perf-observer')) {
+            return 'perf-observer';
+          }
+
+          if (id.includes('pages/app-login')) {
+            return 'app-login';
+          }
+
           if (id.includes('node_modules')) {
             if (
               id.includes('/node_modules/lit') ||
@@ -311,6 +323,10 @@ export default defineConfig({
 
             if (id.includes('/node_modules/idb-keyval')) {
               return 'vendor-idb-keyval';
+            }
+
+            if (id.includes('/web-router')) {
+              return 'vendor-web-router';
             }
 
             // Keep tslib in a dedicated chunk so shared TypeScript helper code can


### PR DESCRIPTION
This pull request updates the Vite configuration to optimize code splitting and resource preloading strategies. The main improvements involve more granular chunking for better caching and performance, and preloading additional critical chunks,

**Chunking and Preloading Enhancements:**

* Added `'auth-session'`, `'firebase-'`, and updated `'vendor-idb-keyval'` to the list of chunks preloaded during SSR to improve initial load performance for authentication and offline storage features.
* Introduced new manual chunks for `perf-observer` and `app-login` utilities, enabling parallel loading of these modules.